### PR TITLE
Fix the wrong type of vinput_dev

### DIFF
--- a/vinput.c
+++ b/vinput.c
@@ -17,7 +17,7 @@ static DECLARE_BITMAP(vinput_ids, VINPUT_MINORS);
 static LIST_HEAD(vinput_devices);
 static LIST_HEAD(vinput_vdevices);
 
-static dev_t vinput_dev;
+static int vinput_dev;
 static struct spinlock vinput_lock;
 static struct class vinput_class;
 
@@ -342,7 +342,7 @@ void vinput_unregister(struct vinput_device *dev)
     list_del(&dev->list);
     spin_unlock(&vinput_lock);
 
-    /* unregister all devices of thhis type */
+    /* unregister all devices of this type */
     list_for_each_safe (curr, next, &vinput_vdevices) {
         struct vinput *vinput = list_entry(curr, struct vinput, list);
         if (vinput && vinput->type == dev) {


### PR DESCRIPTION
The type of `vinput_dev` is integer type, not `dev_t` type, since it is a
major number return by `register_chrdev()`.
It may cause the warning raised by Smatch[1]:

```
make[1]: Entering directory '/usr/src/linux-headers-5.11.0-41-generic'
  CC [M]  /home/****/vinput/vinput.o
  CHECK   /home/****/vinput/vinput.c
/home/****/vinput/vinput.c:365 vinput_init() warn: unsigned 'vinput_dev' is never less than zero.
```

Also, fix typo.

[1] https://lwn.net/Articles/691882/